### PR TITLE
Prevent overflow when on small(er) mobile screens.

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
             </div>
             <div class="container" style="height: 60px;"><a class="link-dark" href="mailto:gwellawatte@gmail.com"><i class="fa fa-envelope-o fa-3x" style="padding: 1px;margin: 10px;"></i></a><a href="https://twitter.com/GWellawatte"><i class="fa fa-twitter fa-3x" style="height: 50;width: 50px;color: var(--bs-dark);margin: 10px;"></i></a><a class="link-dark" href="https://github.com/geemi725"><i class="fa fa-github fa-3x"></i></a></div>
         </section>
-        <section class="portfolio-block skills" style="height: 400px;padding: 50px;">
-            <div class="container" style="height: 300px;">
+        <section class="portfolio-block skills">
+            <div class="container">
                 <div class="heading">
                     <h2><br>Interests</h2>
                 </div>


### PR DESCRIPTION
The in-line css height attributes was causing a rendering error and preventing the footer from being displayed correctly.  This PR simply just removes the in-line css.  

*note this may have impacts in other parts of the system.*

![Screenshot from 2021-08-23 23-30-15](https://user-images.githubusercontent.com/772612/130551332-e76bafbc-da29-4cfa-a645-2d0f93bfb573.png)

![Screenshot from 2021-08-23 23-31-41](https://user-images.githubusercontent.com/772612/130551460-15c9e475-d8b4-456f-81c7-bac243b03547.png)
